### PR TITLE
Populating Item from notification stanza

### DIFF
--- a/lib/stanzas/notification_stanza.rb
+++ b/lib/stanzas/notification_stanza.rb
@@ -125,7 +125,7 @@ class Item
 
   def content
     if !@content
-      if content = @node.at_xpath("./atom:entry/atom:summary", {"atom" => "http://www.w3.org/2005/Atom"})
+      if content = @node.at_xpath("./atom:entry/atom:content", {"atom" => "http://www.w3.org/2005/Atom"})
         @content = content.text
       end
     end


### PR DESCRIPTION
Shouldn't Item.content be pulled from atom:content instead of atom:summary?
For example, http://feeds.feedburner.com/TechCrunch has no summary tag but it has a content tag. 
